### PR TITLE
Don´t try to install when it is already installed.

### DIFF
--- a/roles/ruby/tasks/ruby-install.yml
+++ b/roles/ruby/tasks/ruby-install.yml
@@ -8,7 +8,7 @@
 
 - name: Ruby | Installs ruby
   action: shell cd; bash -lc "rbenv install {{ version }}"
-  when: ruby_is_installed.stdout != version
+  when: ruby_is_installed is not defined 
   # Takes no more than 600 secs on a small VM
   async: 600
   poll: 30


### PR DESCRIPTION
When testing against boxes that already have the versions defined,  the playbook failed. This patches the playbook ( tested in ansible 1.3.4 )
